### PR TITLE
fix: edit route to use URL parameter instead of query string

### DIFF
--- a/controllers/sampleController.js
+++ b/controllers/sampleController.js
@@ -1,12 +1,11 @@
 exports.helloWorld = (req, res) => {
     res.send('Hello World from Docker!');
-}
+};
 
 exports.helloWorldWithCustomName = (req, res) => {
-    res.send(`Hello World from Docker! Written by ${req.query.name}`);
-}
+    res.send(`Hello World from Docker! Written by ${req.params.name}`);
+};
 
 exports.helloWorldButNotReally = (req, res) => {
     res.send('If you accessed the 3 of the routes, you got it right.');
-}
-
+};


### PR DESCRIPTION
# What?

Fixes the output of the third practice route to be the expected output based on the `sampleRoutes.js` semantics.

Previously the code needed to visit `http://localhost:4000/*?name=Ean`, but with this PR, it will now return the proper response with `http://localhost:4000/Ean`.

# Why?

The `sampleRoutes.js` has the following `GET` routes:

```js
router.get('/', sampleController.helloWorld);
router.get('/complicatedroute', sampleController.helloWorldButNotReally);
router.get('/:name', sampleController.helloWorldWithCustomName);
```

The third route seems to expect a wildcard string to replace `:name` to be accessed via `req.params.name`, however the `sampleController.js` uses it differently:

```js
exports.helloWorldWithCustomName = (req, res) => {
  res.send(`Hello World from Docker! Written by ${req.query.name}`)
}
```

This leads visiting `127.0.0.1:4000/Ean` to output:

```
Hello World from Docker! Written by undefined
```

Instead of the expected output  by visiting `127.0.0.1:4000/*?name=Ean` in the old code.

```
Hello World from Docker! Written by Ean
```

The commit will change this behavior to match names in the route `127.0.0.1:4000/anyNameGoesHere`.